### PR TITLE
Fix linux-gpib-kernel.dkms kernel headers mismatch

### DIFF
--- a/linux-gpib-kernel/debian/linux-gpib-kernel.dkms
+++ b/linux-gpib-kernel/debian/linux-gpib-kernel.dkms
@@ -1,6 +1,6 @@
 PACKAGE_NAME="linux-gpib-kernel"
 PACKAGE_VERSION="#MODULE_VERSION#"
-MAKE[0]="make clean;make all"
+MAKE[0]="make clean;make all LINUX_SRCDIR=/usr/src/linux-headers-\${kernelver}"
 CLEAN[0]="make clean"
 DEST_MODULE_LOCATION[0]="/updates/dkms"
 DEST_MODULE_LOCATION[1]="/updates/dkms"


### PR DESCRIPTION
# Summary
This change ensures that DKMS uses the correct Linux headers when installing a new kernel. Without this fix, DKMS defaults to the headers of the currently running kernel, which leads to issues when installing a new kernel version.

# Details
Without this change, any significant kernel update can break the GPIB module. This happens because DKMS ends up building the module against the wrong headers (those of the running kernel rather than the new one), which leaves the module in a broken state and unusable.

# Resolution
By explicitly specifying the intended headers, this fix avoids header mismatches, keeping the GPIB module functional across kernel updates.