### PR TITLE
fixing error with renaming of GPIOF_DIR_IN to GPIOD_IN in newer kernels

### DIFF
--- a/linux-gpib-kernel/drivers/gpib/gpio/gpib_bitbang.c
+++ b/linux-gpib-kernel/drivers/gpib/gpio/gpib_bitbang.c
@@ -965,7 +965,7 @@ static int allocate_gpios(void) {
         int j;
         int last = sn7516x ? GPIB_PINS + SN7516X_PINS : GPIB_PINS ;
         for ( j=0 ; j<last ; j++ ) {
-                if (gpio_request_one (gpios_vector[j]+gpio_offset, GPIOF_DIR_IN, NULL)) break;
+                if (gpio_request_one (gpios_vector[j]+gpio_offset, GPIOD_IN, NULL)) break;
                 all_descriptors[j] = gpio_to_desc (gpios_vector[j]+gpio_offset);
         }
         if ( j != last) {                    /* error - undo what already done */


### PR DESCRIPTION
My attempt to fix this error when compiling the linux-gpib kernel driver for newer linux kernels: 

`make -C /lib/modules/`uname -r`/build V=0 modules \
	M="/home/luzia/linux-gpib/linux-gpib-kernel/drivers/gpib" \
	GPIB_TOP_DIR=/home/luzia/linux-gpib/linux-gpib-kernel \
	CONFIG_GPIB_ISA="" \
	GPIB_CONFIG_PCMCIA="0" \
	HAVE_DEV_OF_NODE= \
	GPIB_CONFIG_KERNEL_DEBUG=0
make[1]: Verzeichnis „/usr/src/linux-headers-6.12.41+deb13-amd64“ wird betreten
  CC [M]  /home/luzia/linux-gpib/linux-gpib-kernel/drivers/gpib/gpio/gpib_bitbang.o
/home/luzia/linux-gpib/linux-gpib-kernel/drivers/gpib/gpio/gpib_bitbang.c: In function ‘allocate_gpios’:
/home/luzia/linux-gpib/linux-gpib-kernel/drivers/gpib/gpio/gpib_bitbang.c:968:68: error: ‘GPIOF_DIR_IN’ undeclared (first use in this function); did you mean ‘GPIOD_IN’?
  968 |                 if (gpio_request_one (gpios_vector[j]+gpio_offset, GPIOF_DIR_IN, NULL)) break;
      |                                                                    ^~~~~~~~~~~~
      |                                                                    GPIOD_IN
/home/luzia/linux-gpib/linux-gpib-kernel/drivers/gpib/gpio/gpib_bitbang.c:968:68: note: each undeclared identifier is reported only once for each function it appears in
make[4]: *** [/usr/src/linux-headers-6.12.41+deb13-common/scripts/Makefile.build:234: /home/luzia/linux-gpib/linux-gpib-kernel/drivers/gpib/gpio/gpib_bitbang.o] Fehler 1
make[3]: *** [/usr/src/linux-headers-6.12.41+deb13-common/scripts/Makefile.build:483: /home/luzia/linux-gpib/linux-gpib-kernel/drivers/gpib/gpio] Fehler 2
make[2]: *** [/usr/src/linux-headers-6.12.41+deb13-common/Makefile:1970: /home/luzia/linux-gpib/linux-gpib-kernel/drivers/gpib] Fehler 2
make[1]: *** [/usr/src/linux-headers-6.12.41+deb13-common/Makefile:236: __sub-make] Fehler 2
make[1]: Verzeichnis „/usr/src/linux-headers-6.12.41+deb13-amd64“ wird verlassen
make: *** [Makefile:10: all] Fehler `

Maybe this helps... 